### PR TITLE
feat(config): Add AI assistant instruction files

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -9,7 +9,7 @@
 
 ## Coding standards
 
-1. Use latest versions of libraries and idiomatic approaches as of today
+1. Use idiomatic approaches and library versions compatible with this repository's documented toolchains and constraints (for example, C++17 for C++ code)
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
 3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 
 ## Coding standards
 
-1. Use latest versions of libraries and idiomatic approaches as of today
+1. Use idiomatic approaches and library versions compatible with this repository's documented toolchains and constraints (for example, C++17 for C++ code)
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
 3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -9,7 +9,7 @@
 
 ## Coding standards
 
-1. Use latest versions of libraries and idiomatic approaches as of today
+1. Use idiomatic approaches and library versions compatible with this repository's documented toolchains and constraints (for example, C++17 for C++ code)
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
 3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Coding standards
 
-1. Use latest versions of libraries and idiomatic approaches as of today
+1. Use idiomatic approaches and library versions compatible with this repository's documented toolchains and constraints (for example, C++17 for C++ code)
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
 3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 
 ## Coding standards
 
-1. Use latest versions of libraries and idiomatic approaches as of today
+1. Use idiomatic approaches and library versions compatible with this repository's documented toolchains and constraints (for example, C++17 for C++ code)
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
 3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
 


### PR DESCRIPTION
Closes #1

Copies AI assistant configuration files from https://github.com/mathemage/mathemage:

- `AGENTS.md` - general AI coding assistant instructions (strategy, coding standards, Git/GitHub workflow)
- `.github/copilot-instructions.md` - GitHub Copilot instructions
- `CLAUDE.md` - Claude Code instructions
- `.cursorrules` - Cursor instructions
- `.windsurfrules` - Windsurf instructions

All files enforce:
- Issue → branch → PR workflow
- Commit message format: `type(scope): Message` with optional trailing `#issue`