### PR TITLE
docs(readme): Add MIT license badge #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CompetitiveProgramming
 ======================
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://choosealicense.com/licenses/mit/)
+
 my solutions from various online programming contests/practices
 
 List of profiles


### PR DESCRIPTION
## Summary
- add an MIT license badge to README.md
- link the badge to the choosealicense MIT page

Closes #3